### PR TITLE
Fix support for IE 11 with datasets

### DIFF
--- a/lib/esvg/js/core.js.erb
+++ b/lib/esvg/js/core.js.erb
@@ -51,7 +51,7 @@
       names = {}
       var symbols = Array.prototype.slice.call( document.querySelectorAll( 'svg[id^=esvg] symbol' ) )
       symbols.forEach( function( symbol ) {
-        names[symbol.dataset.name] = symbol
+        names[symbol.getAttribute('data-name')] = symbol
       })
     }
     return names


### PR DESCRIPTION
IE 11 is returning `undefined` when referencing the symbol's
dataset, which is causing the following exception:

```
Unable to get property 'name' of undefined
```

Switching from dataset to `getAttribute()` fixes this.